### PR TITLE
Dont render registration lite until we have identity providers list.

### DIFF
--- a/src/components/RegistrationLiteComponent.js
+++ b/src/components/RegistrationLiteComponent.js
@@ -145,6 +145,8 @@ const RegistrationLiteComponent = ({
 
     const { registerButton } = siteSettings.heroBanner.buttons;
 
+    if (!thirdPartyProviders) return null;
+
     return (
         <>
             <button className={`${styles.button} button is-large`} onClick={() => setIsActive(true)}>


### PR DESCRIPTION
Fixes first load issue where registration lite component won't show all identity providers.
This PR delays component rendering until identity providers list is available.
Need to review Registration Lite widget component and fix reason why its not reacting to prop change.