### PR TITLE
Removing duplicate registration company input

### DIFF
--- a/src/components/summit-my-orders-tickets/components/TicketPopup/TicketPopupEditDetailsForm/TicketPopupEditDetailsForm.js
+++ b/src/components/summit-my-orders-tickets/components/TicketPopup/TicketPopupEditDetailsForm/TicketPopupEditDetailsForm.js
@@ -479,34 +479,12 @@ export const TicketPopupEditDetailsForm = ({
                                     </div>
                                 </div>
 
-                                <div className="row field-wrapper">
+                                <div className="row field-wrapper-unique">
                                     <div className="col-sm-4">
                                         {t("ticket_popup.edit_company")}
                                         {t("ticket_popup.edit_required_star")}
                                     </div>
                                     <div className="col-sm-8" style={{ position: 'relative' }}>
-                                        {(readOnly || !shouldEditBasicInfo) && (
-                                            <span>{ticket.owner?.company}</span>
-                                        )}
-
-                                        {(!readOnly && shouldEditBasicInfo) && (
-                                            <RegistrationCompanyInput
-                                                id="attendee_company"
-                                                name="attendee_company"
-                                                summitId={summit.id}
-                                                className={`dropdown`}                                                
-                                                onChange={formik.handleChange}
-                                                onBlur={formik.handleblur}
-                                                value={formik.values.attendee_company}
-                                                error={formik.errors.attendee_company?.name}
-                                            />
-                                        )}
-                                    </div>
-                                </div>
-
-                                <div className="field-wrapper-mobile">
-                                    <div>{t("ticket_popup.edit_company")}{t("ticket_popup.edit_required_star")}</div>
-                                    <div style={{ position: 'relative' }}>
                                         {(readOnly || !shouldEditBasicInfo) && (
                                             <span>{ticket.owner?.company}</span>
                                         )}

--- a/src/components/summit-my-orders-tickets/components/TicketPopup/TicketPopupEditDetailsForm/ticket-popup-edit-details-form.scss
+++ b/src/components/summit-my-orders-tickets/components/TicketPopup/TicketPopupEditDetailsForm/ticket-popup-edit-details-form.scss
@@ -21,7 +21,7 @@
     }
   }
 
-  .field-wrapper {
+  .field-wrapper, .field-wrapper-unique {
     margin-top: 10px;
     margin-bottom: 10px;
     display: flex;
@@ -254,6 +254,17 @@
 
     .field-wrapper {
       display: none;
+    }
+
+    .field-wrapper-unique {    
+      display: flex;
+      flex-direction: column;
+      .col-sm-4 {
+        width: 100%;
+      }
+      .col-sm-8 {
+        width: 100%;
+      }
     }
 
     .field-wrapper--textarea {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

* Unify HTML template for mobile and dekstop sharing the same registration company input component

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing


ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=3001700

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
