### PR TITLE
Add default value for id as null to fix missing adds

### DIFF
--- a/src/components/AdvertiseComponent.js
+++ b/src/components/AdvertiseComponent.js
@@ -4,7 +4,7 @@ import Ad from "./Ad";
 
 import styles from '../styles/advertise.module.scss'
 
-const AdvertiseComponent = ({ section, column, id }) => {
+const AdvertiseComponent = ({ section, column, id = null }) => {
     const sectionAds = Content.ads.find(ad => ad.section === section)?.columnAds.filter(c => c.column === column) || [];
 
     if (sectionAds.length === 0) return null;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

* Fixes the missing ads on lobby

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

This bugs happens when the ads are saved through the CMS with id as null, on the render checks returns a null component. We should review the use of the id prop (**Specific event?** on CMS) because right now any prod site seems to use it.

ref: https://tipit.avaza.com/project/view#!tab=task-pane&groupby=MyTaskProject&view=vertical&task=3075326&fileview=grid

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>