### PR TITLE
Adds default id for ads, change conditions to render null

### DIFF
--- a/src/components/AdvertiseComponent.js
+++ b/src/components/AdvertiseComponent.js
@@ -31,7 +31,7 @@ const AdvertiseComponent = ({ section, column, id }) => {
                 )
             }
 
-            if (ad.id !== id || column === 'center') return null;
+            if((ad.hasOwnProperty('id') && id && ad.id && ad.id !== id) || column === 'center') return null
 
             const wrapperClass =`${index === 0 ? styles.firstSponsorContainer : styles.sponsorContainer} sponsor-container`;
 

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -53,7 +53,7 @@ collections:
                   {label: "Center", value: "center" },
                   {label: "Right", value: "right" },
                 ]},
-                {label: "Specific Event?", name: "id", widget: string, required: false}              
+                {label: "Specific Event?", name: "id", widget: string, required: false, default: 0}
               ]},
             ]}
       - file: "src/content/sponsors-tiers.json"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

* Fix the missing ads when the id was null

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

* We should review if any site has any undesired ad with id equals to null and remove it since right now is not beign rendered

ref: https://tipit.avaza.com/project/view#!tab=task-pane&groupby=MyTaskProject&view=vertical&task=3075326&fileview=grid

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>