### PR TITLE
Tab name. Add unassign option. Change actions for reassign

### DIFF
--- a/src/components/summit-my-orders-tickets/components/ConfirmPopup/ConfirmPopup.js
+++ b/src/components/summit-my-orders-tickets/components/ConfirmPopup/ConfirmPopup.js
@@ -21,6 +21,7 @@ export const CONFIRM_POPUP_CASE = {
     CANCEL_TICKET: 'CANCEL_TICKET',
     ASSIGN_TICKET: 'ASSIGN_TICKET',
     REASSIGN_TICKET: 'REASSIGN_TICKET',
+    UNASSIGN_TICKET: 'UNASSIGN_TICKET',
     SAVE: 'SAVE',
     NOTIFICATION: 'NOTIFICATION',
 }
@@ -42,6 +43,10 @@ export const getConfirmPopupContent = ({ popupCase, cleanFields }) => {
         [CONFIRM_POPUP_CASE.REASSIGN_TICKET]: {
             title: 'confirm_popup.question_title_reassign',
             text: cleanFields ? 'confirm_popup.question_text_reassign' : 'confirm_popup.question_text_confirm'
+        },
+        [CONFIRM_POPUP_CASE.REASSIGN_TICKET]: {
+            title: 'confirm_popup.question_title_unassign',
+            text: 'confirm_popup.question_text_unassign'
         },
         [CONFIRM_POPUP_CASE.SAVE]: {
             title: 'confirm_popup.question_title_save',

--- a/src/components/summit-my-orders-tickets/components/TicketPopup/TicketPopup.js
+++ b/src/components/summit-my-orders-tickets/components/TicketPopup/TicketPopup.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Tabs, TabList, Tab, TabPanel } from 'react-tabs';
 import { useTranslation } from "react-i18next";
@@ -34,6 +34,8 @@ export const TicketPopup = ({ ticket, order, summit, onClose, fromTicketList, fr
     const isUserTicketOwner = ticket.owner?.email === userProfile.email;
 
     const canEditTicketData = (isUserTicketOwner || isUserOrderOwner) && summit.allow_update_attendee_extra_questions;
+
+    const [tabIndex, setTabIndex] = useState(0);
 
     useEffect(() => {
         document.body.style.overflow = 'hidden';
@@ -89,7 +91,7 @@ export const TicketPopup = ({ ticket, order, summit, onClose, fromTicketList, fr
                 </header>
 
                 <section className="ticket-popup-body">
-                    <Tabs selectedTabClassName="ticket-popup-tabs--active">
+                    <Tabs selectedIndex={tabIndex} onSelect={(index) => setTabIndex(index)} selectedTabClassName="ticket-popup-tabs--active">
                         <TabList className="ticket-popup-tabs">
                             {isUnassigned && (
                                 <Tab>{t("ticket_popup.tab_assign")}</Tab>
@@ -125,6 +127,7 @@ export const TicketPopup = ({ ticket, order, summit, onClose, fromTicketList, fr
                                     summit={summit}
                                     order={order}
                                     canEditTicketData={canEditTicketData}
+                                    goToReassignPanel={() => setTabIndex(1)}
                                     context={fromTicketList ? 'ticket-list' : 'order-list'}
                                 />
                             </div>

--- a/src/components/summit-my-orders-tickets/components/TicketPopup/TicketPopupEditDetailsForm/TicketPopupEditDetailsForm.js
+++ b/src/components/summit-my-orders-tickets/components/TicketPopup/TicketPopupEditDetailsForm/TicketPopupEditDetailsForm.js
@@ -21,6 +21,7 @@ export const TicketPopupEditDetailsForm = ({
     summit,
     order,
     canEditTicketData,
+    goToReassignPanel,
     context    
 }) => {
     const formRef = useRef(null);
@@ -157,7 +158,7 @@ export const TicketPopupEditDetailsForm = ({
 
     const handleConfirmReject = () => {
         setShowConfirm(false);        
-    };    
+    };
 
     const handleSubmit = (values, formikHelpers) => updateTicket(values, formikHelpers);
 
@@ -314,7 +315,7 @@ export const TicketPopupEditDetailsForm = ({
                                                 {(isUserTicketOwner && isReassignable) && (
                                                     <>
                                                         <br />
-                                                        <span onClick={() => setChangeAttendee(true)}>
+                                                        <span onClick={() => goToReassignPanel()}>
                                                             <u>Reassign</u>
                                                         </span>
                                                         {` | `}
@@ -389,7 +390,7 @@ export const TicketPopupEditDetailsForm = ({
                                                 {(isUserTicketOwner && isReassignable) && (
                                                     <>
                                                         <br />
-                                                        <span onClick={() => setChangeAttendee(true)}>
+                                                        <span onClick={() => goToReassignPanel()}>
                                                             <u>Reassign</u>
                                                         </span>
                                                         {` | `}

--- a/src/components/summit-my-orders-tickets/components/TicketPopup/TicketPopupReassignForm.js
+++ b/src/components/summit-my-orders-tickets/components/TicketPopup/TicketPopupReassignForm.js
@@ -6,7 +6,7 @@ import Alert from 'react-bootstrap/lib/Alert';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import { Input } from 'openstack-uicore-foundation/lib/components'
-import { removeAttendee } from "../../store/actions/ticket-actions";
+import { changeTicketAttendee } from "../../store/actions/ticket-actions";
 import { ConfirmPopup, CONFIRM_POPUP_CASE } from "../ConfirmPopup/ConfirmPopup";
 import { getSummitFormattedReassignDate } from "../../util";
 
@@ -55,7 +55,7 @@ export const TicketPopupReassignForm = ({ ticket, summit, order }) => {
         formik.resetForm();
         setNewAttendeeEmail('');
 
-        dispatch(removeAttendee({
+        dispatch(changeTicketAttendee({
             ticket,
             order,
             data: { attendee_email: newAttendeeEmail }

--- a/src/components/summit-my-orders-tickets/i18n/locales/en.json
+++ b/src/components/summit-my-orders-tickets/i18n/locales/en.json
@@ -179,6 +179,7 @@
         "save_message": "Thank you! Your information has been saved and ticket updated.",
         "assign_success_message": "The ticket was successfully assigned.",
         "reassign_success_message": "The ticket was successfully reassigned.",
+        "unassign_success_message": "The ticket was successfully unassigned.",
         "notify_success_message": "Notification was sent to ticket holder.",
         "refund_request_success_message": "Your refund request has been received. Please allow 24 - 48 hours for a response."
     },
@@ -195,7 +196,7 @@
     },
     "ticket_popup": {
         "tab_assign": "Assign",
-        "tab_reassign": "Re-Assign",
+        "tab_reassign": "Reassign",
         "tab_refund": "Refund",
         "tab_edit": "Edit Details",
         "tab_edit_read_only": "Details",
@@ -241,6 +242,8 @@
         "question_text_cancel_order": "Are you sure you want to request a refund of this entire order ?",
         "question_title_assign": "Assign Request",
         "question_text_assign": "Are you sure you want to clean all the fields?",
+        "question_title_unassign": "Unassign Request",
+        "question_text_unassign": "Are you sure you want to unassign this ticket?",
         "question_title_reassign": "Re-Assign Request",
         "question_text_reassign": "Are you sure you want to clean all the fields?",
         "question_title_save": "Save",

--- a/src/components/summit-my-orders-tickets/i18n/locales/es.json
+++ b/src/components/summit-my-orders-tickets/i18n/locales/es.json
@@ -179,6 +179,7 @@
         "save_message": "Thank you! Your information has been saved and ticket updated.",
         "assign_success_message": "The ticket was successfully assigned.",
         "reassign_success_message": "The ticket was successfully reassigned.",
+        "unassign_success_message": "The ticket was successfully unassigned.",
         "notify_success_message": "Notification was sent to ticket holder.",
         "refund_request_success_message": "Your refund request has been received. Please allow 24 - 48 hours for a response."
     },
@@ -195,7 +196,7 @@
     },
     "ticket_popup": {
         "tab_assign": "Assign",
-        "tab_reassign": "Re-Assign",
+        "tab_reassign": "Reassign",
         "tab_refund": "Refund",
         "tab_edit": "Edit Details",
         "tab_edit_read_only": "Details",
@@ -241,6 +242,8 @@
         "question_text_cancel_order": "Are you sure you want to request a refund of this entire order ?",
         "question_title_assign": "Assign Request",
         "question_text_assign": "Are you sure you want to clean all the fields?",
+        "question_title_unassign": "Unassign Request",
+        "question_text_unassign": "Are you sure you want to unassign this ticket?",
         "question_title_reassign": "Re-Assign Request",
         "question_text_reassign": "Are you sure you want to clean all the fields?",
         "question_title_save": "Save",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

* Change names on tab and edit form
* Add unassign option on edit tab

<img width="559" alt="image" src="https://user-images.githubusercontent.com/19543853/199578948-eb9462aa-8dc8-4580-a3e5-8a1f72449976.png">

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=3088446

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>