### PR TITLE
Add QR code on ticket popup when it's ready to use

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "react-iframe-comm": "^1.2.2",
     "react-masonry-css": "^1.0.14",
     "react-medium-image-zoom": "^4.3.5",
+    "react-qr-code": "^2.0.8",
     "react-redux": "^7.2.6",
     "react-rte": "^0.16.3",
     "react-select": "^2.4.4",

--- a/src/components/summit-my-orders-tickets/components/TicketPopup/TicketPopup.js
+++ b/src/components/summit-my-orders-tickets/components/TicketPopup/TicketPopup.js
@@ -11,6 +11,8 @@ import { TicketPopupNotifyForm } from './TicketPopupNotifyForm';
 import { TicketPopupRefundForm } from './TicketPopupRefundForm';
 import { TicketPopupEditDetailsForm } from './TicketPopupEditDetailsForm/TicketPopupEditDetailsForm';
 
+import QRCode from "react-qr-code";
+
 import './ticket-popup.scss';
 
 export const TicketPopup = ({ ticket, order, summit, onClose, fromTicketList, fromOrderList, className }) => {
@@ -80,11 +82,23 @@ export const TicketPopup = ({ ticket, order, summit, onClose, fromTicketList, fr
                     </div>
 
                     <div className="ticket-popup-icons">
-                        {!summit.is_virtual && (
+                        <div className='ticket-popup-row-icon'>
+                        {!summit.is_virtual && statusData.type === 'STATUS_COMPLETE' && (
                             <i onClick={handleDownloadClick} className="fa fa-file-pdf-o" />
                         )}
 
                         <i onClick={handleCloseClick} className="fa fa-times" />
+                        </div>
+                        {statusData.type === 'STATUS_COMPLETE' &&
+                            <div className='ticket-popup-qr'>
+                                <QRCode
+                                    size={256}
+                                    style={{ height: "auto", maxWidth: "100%", width: "100%" }}
+                                    value={ticket.qr_code}
+                                    viewBox={`0 0 256 256`}
+                                />
+                            </div>
+                        }
                     </div>
                 </header>
 

--- a/src/components/summit-my-orders-tickets/components/TicketPopup/ticket-popup.scss
+++ b/src/components/summit-my-orders-tickets/components/TicketPopup/ticket-popup.scss
@@ -68,10 +68,22 @@
 
   .ticket-popup-icons {
     display: flex;
-    justify-content: flex-end;
     gap: 15px;
-    width: 10%;
+    width: 90px;
     color: $color-primary-contrast;
+    flex-direction: column;    
+
+    .ticket-popup-row-icon {
+      display: flex;
+      gap: 15px;
+      justify-content: end;
+    }
+
+    .ticket-popup-qr {
+      width: 90px;
+      margin-left: auto;
+      display: flex;
+    }
 
     i {
       font-size: 1.5em;
@@ -350,7 +362,7 @@
 
   .ticket-popup-header {
     .ticket-popup-icons {
-      width: 20%;
+      width: 90px;
 
       i {
         margin-left: 10px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12210,18 +12210,7 @@ pupa@^2.1.1:
   dependencies:
     escape-goat "^2.0.0"
 
-pure-react-carousel@^1.27.4:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/pure-react-carousel/-/pure-react-carousel-1.30.1.tgz#006a333869b51339dafcdee2afa0561eb46d1743"
-  integrity sha512-B1qi62hZk0OFqRR4cTjtgIeOn/Ls5wo+HsLtrXT4jVf5et8ldBHSt+6LsYRJN86Or8dm+XbnJNEHy6WDJ0/DQw==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    deep-freeze "0.0.1"
-    deepmerge "^2.2.1"
-    equals "^1.0.5"
-    prop-types "^15.6.2"
-
-pure-react-carousel@^1.30.1:
+pure-react-carousel@^1.27.4, pure-react-carousel@^1.30.1:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/pure-react-carousel/-/pure-react-carousel-1.30.1.tgz#006a333869b51339dafcdee2afa0561eb46d1743"
   integrity sha512-B1qi62hZk0OFqRR4cTjtgIeOn/Ls5wo+HsLtrXT4jVf5et8ldBHSt+6LsYRJN86Or8dm+XbnJNEHy6WDJ0/DQw==
@@ -12241,6 +12230,11 @@ purgecss@^4.1.3:
     glob "^7.1.7"
     postcss "^8.3.5"
     postcss-selector-parser "^6.0.6"
+
+qr.js@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/qr.js/-/qr.js-0.0.0.tgz#cace86386f59a0db8050fa90d9b6b0e88a1e364f"
+  integrity sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==
 
 qs@6.11.0, qs@^6.9.4:
   version "6.11.0"
@@ -12877,6 +12871,14 @@ react-property@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-property/-/react-property-1.0.1.tgz#4ae4211557d0a0ae050a71aa8ad288c074bea4e6"
   integrity sha512-1tKOwxFn3dXVomH6pM9IkLkq2Y8oh+fh/lYW3MJ/B03URswUTqttgckOlbxY2XHF3vPG6uanSc4dVsLW/wk3wQ==
+
+react-qr-code@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/react-qr-code/-/react-qr-code-2.0.8.tgz#d34a766fb5b664a40dbdc7020f7ac801bacb2851"
+  integrity sha512-zYO9EAPQU8IIeD6c6uAle7NlKOiVKs8ji9hpbWPTGxO+FLqBN2on+XCXQvnhm91nrRd306RvNXUkUNcXXSfhWA==
+  dependencies:
+    prop-types "^15.8.1"
+    qr.js "0.0.0"
 
 react-redux@^4.0.0:
   version "4.4.10"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

<img width="893" alt="image" src="https://user-images.githubusercontent.com/19543853/199748669-5bc21185-214e-49d7-a4e1-01922b146e18.png">


* Adds the QR of the ticket when it's ready to use
* Hide PDF icon when the ticket isn't ready to use

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=3088589

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>