### PR TITLE
Change assign note, make basic info read only on ticket popup

### DIFF
--- a/src/components/summit-my-orders-tickets/components/TicketPopup/TicketPopupEditDetailsForm/TicketPopupEditDetailsForm.js
+++ b/src/components/summit-my-orders-tickets/components/TicketPopup/TicketPopupEditDetailsForm/TicketPopupEditDetailsForm.js
@@ -425,7 +425,7 @@ export const TicketPopupEditDetailsForm = ({
                                         {t("ticket_popup.edit_required_star")}
                                     </div>
                                     <div className="col-sm-8">
-                                        {canEditTicketData || !ticket.owner.first_name ?
+                                        {!ticket.owner?.first_name ?
                                             <Input
                                                 id="attendee_first_name"
                                                 name="attendee_first_name"
@@ -447,7 +447,7 @@ export const TicketPopupEditDetailsForm = ({
                                         {t("ticket_popup.edit_required_star")}
                                     </div>
                                     <div>
-                                        {canEditTicketData || !ticket.owner.first_name ?
+                                        {!ticket.owner?.first_name ?
                                             <Input
                                                 id="attendee_first_name"
                                                 name="attendee_first_name"
@@ -469,7 +469,7 @@ export const TicketPopupEditDetailsForm = ({
                                         {t("ticket_popup.edit_required_star")}
                                     </div>
                                     <div className="col-sm-8">
-                                        {canEditTicketData || !ticket.owner.last_name ?
+                                        {!ticket.owner?.last_name ?
                                             <Input
                                                 id="attendee_last_name"
                                                 name="attendee_last_name"
@@ -491,7 +491,7 @@ export const TicketPopupEditDetailsForm = ({
                                         {t("ticket_popup.edit_required_star")}
                                     </div>
                                     <div>
-                                        {canEditTicketData || !ticket.owner.last_name ?
+                                        {!ticket.owner?.last_name ?
                                             <Input
                                                 id="attendee_last_name"
                                                 name="attendee_last_name"
@@ -513,7 +513,7 @@ export const TicketPopupEditDetailsForm = ({
                                         {t("ticket_popup.edit_required_star")}
                                     </div>
                                     <div className="col-sm-8" style={{ position: 'relative' }}>
-                                        {canEditTicketData || !ticket.owner.company ?
+                                        {!ticket.owner?.company ?
                                             <RegistrationCompanyInput
                                                 id="attendee_company"
                                                 name="attendee_company"

--- a/src/components/summit-my-orders-tickets/i18n/locales/en.json
+++ b/src/components/summit-my-orders-tickets/i18n/locales/en.json
@@ -220,7 +220,7 @@
         "edit_basic_info": "Attendee Information",
         "edit_required": "* Required Fields",
         "edit_email": "Ticket assigned to email:",
-        "assign_note": "NOTE: Changing the name below will not reassign the ticket.  You must change the email address.",
+        "assign_note": "Note: Should the ticket holder wish to change their name or company info, they can do so by logging into the event site and clicking on the profile icon (located on the far right of the top navigation bar).",
         "edit_first_name": "First Name",
         "edit_last_name": "Last Name",
         "edit_company": "Company",

--- a/src/components/summit-my-orders-tickets/i18n/locales/es.json
+++ b/src/components/summit-my-orders-tickets/i18n/locales/es.json
@@ -220,7 +220,7 @@
         "edit_basic_info": "Attendee Information",
         "edit_required": "* Required Fields",
         "edit_email": "Ticket assigned to email:",
-        "assign_note": "NOTE: Changing the name below will not reassign the ticket.  You must change the email address.",
+        "assign_note": "Note: Should the ticket holder wish to change their name or company info, they can do so by logging into the event site and clicking on the profile icon (located on the far right of the top navigation bar).",
         "edit_first_name": "First Name",
         "edit_last_name": "Last Name",
         "edit_company": "Company",


### PR DESCRIPTION
**What kind of change does this PR introduce?**

* On ticket popup, user can't edit the basic info unless it's empty

<img width="898" alt="image" src="https://user-images.githubusercontent.com/19543853/199824862-f4d66374-15f6-4142-b91a-132767c49cec.png">
<img width="887" alt="image" src="https://user-images.githubusercontent.com/19543853/199824904-55a0dbf8-c93b-461a-a40e-5238baa29aed.png">


**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=3088442

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>