### PR TITLE
Add margin to ticket QR, adjust unnassign text

### DIFF
--- a/src/components/summit-my-orders-tickets/components/ConfirmPopup/ConfirmPopup.js
+++ b/src/components/summit-my-orders-tickets/components/ConfirmPopup/ConfirmPopup.js
@@ -44,7 +44,7 @@ export const getConfirmPopupContent = ({ popupCase, cleanFields }) => {
             title: 'confirm_popup.question_title_reassign',
             text: cleanFields ? 'confirm_popup.question_text_reassign' : 'confirm_popup.question_text_confirm'
         },
-        [CONFIRM_POPUP_CASE.REASSIGN_TICKET]: {
+        [CONFIRM_POPUP_CASE.UNASSIGN_TICKET]: {
             title: 'confirm_popup.question_title_unassign',
             text: 'confirm_popup.question_text_unassign'
         },

--- a/src/components/summit-my-orders-tickets/components/TicketPopup/TicketPopupEditDetailsForm/TicketPopupEditDetailsForm.js
+++ b/src/components/summit-my-orders-tickets/components/TicketPopup/TicketPopupEditDetailsForm/TicketPopupEditDetailsForm.js
@@ -625,7 +625,7 @@ export const TicketPopupEditDetailsForm = ({
                 </>
                 <ConfirmPopup
                     isOpen={showConfirm}
-                    popupCase={CONFIRM_POPUP_CASE.REASSIGN_TICKET}
+                    popupCase={CONFIRM_POPUP_CASE.UNASSIGN_TICKET}
                     onAccept={handleConfirmAccept}
                     onReject={handleConfirmReject}
                 />

--- a/src/components/summit-my-orders-tickets/components/TicketPopup/ticket-popup.scss
+++ b/src/components/summit-my-orders-tickets/components/TicketPopup/ticket-popup.scss
@@ -83,6 +83,8 @@
       width: 90px;
       margin-left: auto;
       display: flex;
+      padding: 3px;
+      background-color: #fff;
     }
 
     i {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

<img width="663" alt="image" src="https://user-images.githubusercontent.com/19543853/200853934-6689fb4a-a590-4e03-a62c-7f28a30f4bce.png">

* Adds margin to ticket QR code
* Fixes unnasign tickets popup texts

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing

ref: 
* https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=3088589
* https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=3088446

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>