### PR TITLE
Change useSelector declaration, add shallowEqual

### DIFF
--- a/src/components/ProfilePopupComponent.js
+++ b/src/components/ProfilePopupComponent.js
@@ -253,11 +253,10 @@ const ProfilePopupComponent = ({ userProfile, idpLoading, closePopup, showProfil
                   <div className='column is-one-quarter'>First Name</div>
                   <div className='column is-two-thirds'>
                     <input
-                        className={`${styles.input} ${styles.isMedium} ${styles.readOnly}`}
+                        className={`${styles.input} ${styles.isMedium}`}
                         type="text"
                         placeholder="First Name"
                         onChange={e => setFirstName(e.target.value)}
-                        readOnly={true}
                         value={firstName} />
                   </div>
                 </div>
@@ -265,11 +264,10 @@ const ProfilePopupComponent = ({ userProfile, idpLoading, closePopup, showProfil
                   <div className='column is-one-quarter'>Last Name</div>
                   <div className='column is-two-thirds'>
                     <input
-                        className={`${styles.input} ${styles.isMedium} ${styles.readOnly}`}
+                        className={`${styles.input} ${styles.isMedium}`}
                         type="text"
                         placeholder="Last Name"
                         onChange={e => setLastName(e.target.value)}
-                        readOnly={true}
                         value={lastName} />
                   </div>
                 </div>
@@ -277,9 +275,8 @@ const ProfilePopupComponent = ({ userProfile, idpLoading, closePopup, showProfil
                   <div className='column is-one-quarter'>Company</div>
                   <div className='column is-two-thirds'>
                     <input
-                        className={`${styles.input} ${styles.isMedium} ${styles.readOnly}`}
+                        className={`${styles.input} ${styles.isMedium}`}
                         type="text"
-                        readOnly={true}
                         placeholder="Company"
                         onChange={e => setCompany(e.target.value)}
                         value={company}

--- a/src/components/summit-my-orders-tickets/components/MyOrdersTickets.js
+++ b/src/components/summit-my-orders-tickets/components/MyOrdersTickets.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { useTranslation } from "react-i18next";
 import classNames from 'classnames';
 import { AjaxLoader } from "openstack-uicore-foundation/lib/components";
@@ -12,13 +12,12 @@ import { TicketList } from './TicketList/TicketList';
 export const MyOrdersTickets = ({ className }) => {
     const { t } = useTranslation();
     const dispatch = useDispatch();
-    const {
-        userState,
-        orderState,
-        ticketState,
-        summitState,
-        globalState
-    } = useSelector(state => state || {});
+
+    const userState = useSelector(state => state.userState || {}, shallowEqual);
+    const orderState = useSelector(state => state.orderState || {}, shallowEqual);
+    const ticketState = useSelector(state => state.ticketState || {}, shallowEqual);
+    const summitState = useSelector(state => state.summitState || {}, shallowEqual);
+    const globalState = useSelector(state => state.globalState || {}, shallowEqual);
 
     const [isInitializing, setIsInitializing] = useState(true);
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

* Changes useSelector declarations and add shallowEqual to avoid the component to re render every second
* Removes the readOnly prop for profile popup fields (Originally used on yahoo event)

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=3096115

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>