### PR TITLE
Add space before extra questions

### DIFF
--- a/src/templates/extra-questions-page.js
+++ b/src/templates/extra-questions-page.js
@@ -132,9 +132,13 @@ export const ExtraQuestionsPageTemplate = ({ user, summit, extraQuestions, saveE
                         <>
                             <h2>Additional Information</h2>
                             <span>
-                                Please answer these additional questions.
+                                <p>
+                                    Please answer these additional questions.
+                                </p>
+                                <p>
+                                    * Required questions
+                                </p>
                                 <br />
-                                * Required questions
                             </span>
                             <div>
                                 <ExtraQuestionsForm


### PR DESCRIPTION
**What kind of change does this PR introduce?**

* Adds spacing before extra questions
<img width="945" alt="image" src="https://user-images.githubusercontent.com/19543853/211557527-63fbc70d-58a9-4801-9489-ac38e3740f5d.png">

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=3119608

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
