### PR TITLE
Fix bug with mobile order summary, adjust currency symbol

### DIFF
--- a/src/components/summit-my-orders-tickets/components/OrderList/OrderListItem.js
+++ b/src/components/summit-my-orders-tickets/components/OrderList/OrderListItem.js
@@ -29,7 +29,7 @@ export const OrderListItem = ({ order, className, changeTicketsPage }) => {
 
                     {isActive && tickets.length > 0 && (
                         <>
-                            <OrderSummary type="mobile" order={order} summit={summit} />
+                            <OrderSummary type="mobile" order={order} summit={summit} tickets={tickets}/>
 
                             {summit.ticket_types.map((ticketType, index) => {
                                 const orderTickets = tickets.filter(t => t.ticket_type_id == ticketType.id);

--- a/src/components/summit-my-orders-tickets/components/OrderSummary/OrderSummary.js
+++ b/src/components/summit-my-orders-tickets/components/OrderSummary/OrderSummary.js
@@ -48,7 +48,7 @@ export const OrderSummary = ({ type = 'desktop', order, summit, tickets, classNa
                 <div className="order-summary-mobile-title" onClick={handleToggleClick}>
                     <span>{t("order_summary.order_summary")}</span>
                     <span>
-                        ${amountTotal} &nbsp; <i className={`fa fa-chevron-${showTable ? 'up' : 'down'}`} aria-hidden="true"></i>
+                        {amountTotal} &nbsp; <i className={`fa fa-chevron-${showTable ? 'up' : 'down'}`} aria-hidden="true"></i>
                     </span>
                 </div>
             )}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

* Fix the issue with the order summary on mobile
* Adjust currency symbol on mobile order summary

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing

ref: https://tipit.avaza.com/project/view/140576#!tab=task-pane&task=3202280

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>