### PR TITLE
Add badge expands on ticket reassign, to reevaluate access

### DIFF
--- a/src/components/summit-my-orders-tickets/store/actions/ticket-actions.js
+++ b/src/components/summit-my-orders-tickets/store/actions/ticket-actions.js
@@ -203,7 +203,7 @@ export const assignAttendee = ({
 
     const params = {
         access_token: accessToken,
-        expand: 'owner, owner.extra_questions'
+        expand: 'owner,owner.extra_questions,badge,badge.type,badge.type.access_levels'
     };
 
     const normalizedEntity =

--- a/src/routes/WithAuthzRoute.js
+++ b/src/routes/WithAuthzRoute.js
@@ -45,7 +45,7 @@ const WithAuthzRoute = ({
     // we store this calculation to use it later
     const hasVirtualBadge = useMemo(() =>
         userProfile ? userHasAccessLevel(userProfile.summit_tickets, VirtualAccessLevel) : false,
-        [userProfile]);
+        [userProfile.summit_tickets]);
 
     const userIsReady = () => {
         // we have an user profile


### PR DESCRIPTION
**What kind of change does this PR introduce?**

* Add missing expands on ticket reassign to have the required data to reevaluate user access.

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=3245270

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
